### PR TITLE
Add support for additional Datadog site regions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 __pycache__/
 *.py[cod]
 *$py.class
+.DS_Store
 
 # C extensions
 *.so
@@ -14,7 +15,6 @@ dist/
 downloads/
 eggs/
 .eggs/
-# lib/
 lib64/
 parts/
 sdist/

--- a/globalConfig.json
+++ b/globalConfig.json
@@ -2,9 +2,9 @@
     "meta": {
         "name": "TA-splunk-add-on-for-datadog-api",
         "displayName": "Datadog Add-on for Splunk",
-        "version": "2.0.1",
+        "version": "2.0.2",
         "restRoot": "TA_splunk_add_on_for_datadog_api",
-        "schemaVersion": "0.0.10"
+        "schemaVersion": "0.0.9"
     },
     "pages": {
         "configuration": {
@@ -88,16 +88,32 @@
                                 "disableSearch": true,
                                 "autoCompleteFields": [
                                     {
-                                        "value": "datadoghq.com",
-                                        "label": "datadoghq.com"
+                                        "value": "https://app.datadoghq.com",
+                                        "label": "US1"
                                     },
                                     {
-                                        "value": "datadoghq.eu",
-                                        "label": "datadoghq.eu"
+                                        "value": "https://us3.datadoghq.com",
+                                        "label": "US3"
                                     },
                                     {
-                                        "value": "ddog-gov.com",
-                                        "label": "ddog-gov.com"
+                                        "value": "https://us5.datadoghq.com",
+                                        "label": "US5"
+                                    },
+                                    {
+                                        "value": "https://app.datadoghq.eu",
+                                        "label": "EU1"
+                                    },
+                                    {
+                                        "value": "https://app.ddog-gov.com",
+                                        "label": "US1-FED"
+                                    },
+                                    {
+                                        "value": "https://ap1.datadoghq.com",
+                                        "label": "AP1"
+                                    },
+                                    {
+                                        "value": "https://ap2.datadoghq.com",
+                                        "label": "AP2"
                                     }
                                 ]
                             },

--- a/package/bin/input_module_datadog_event_stream.py
+++ b/package/bin/input_module_datadog_event_stream.py
@@ -50,7 +50,7 @@ def get_slice_time(start, end, steps):
 
 
 def build_event_url(datadog_site, start, end, priority, sources, tags, unaggregated):
-    endpoint = "https://api.{}/api/v1/events?".format(datadog_site)
+    endpoint = "{}/api/v1/events?".format(datadog_site)
     param = "start=" + str(start)
     param += "&end=" + str(end)
     if priority:

--- a/package/bin/input_module_datadog_metric_inventory.py
+++ b/package/bin/input_module_datadog_metric_inventory.py
@@ -51,7 +51,7 @@ def get_slice_time(start, end, steps):
 
 
 def build_metric_url(datadog_site, start, end, query):
-    endpoint = "https://app.{}/api/v1/query?".format(datadog_site)
+    endpoint = "{}/api/v1/query?".format(datadog_site)
     param = "&from=" + str(start)
     param += "&to=" + str(end)
     param += "&query=" + query


### PR DESCRIPTION
## Summary
Add support for configuring additional Datadog site regions: US3, US5, US1-FED, AP1, AP2.
The integration was tested with Datadog accounts in these sites.
